### PR TITLE
Specify rescue from LoadError for ransack

### DIFF
--- a/lib/active_reporting.rb
+++ b/lib/active_reporting.rb
@@ -12,7 +12,7 @@ require 'active_reporting/version'
 begin
   require 'ransack'
   ActiveReporting::Configuration.ransack_available = true
-rescue
+rescue LoadError, StandardError
   ActiveReporting::Configuration.ransack_available = false
 end
 


### PR DESCRIPTION
Fixes automatic setting of 'ransack_available' to false; empty
'rescue' directive only rescues StandardError, which LoadError
does not inherit from.

See https://ruby-doc.org/core-2.5.0/ScriptError.html