### PR TITLE
Implicit datetime column hierarchies in PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,24 @@ class PhoneFactModel < ActiveReporting::FactModel
 end
 ```
 
+### Implicit hierarchies with datetime columns (PostgreSQL support only)
+
+The fastest approach to group by certain date metrics is to create so-called "date dimensions". For
+those Postgres users that are restricted from organizing their data in this way, Postgres provides
+a way to group by `datetime` column data on the fly using the `date_trunc` function.
+
+To use, declare a datetime dimension on a fact model as normal:
+
+```ruby
+class UserFactModel < ActiveReporting::FactModel
+  dimension :created_at
+end
+```
+
+When creating a metric, ActiveReporting will recognize implicit hierarchies for this dimension. The hierarchies correspond to the [values](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC) supported by PostgreSQL. (See example under the metric section, below.)
+
+*NOTE*: PRs welcomed to support this functionality in other databases.
+
 ## Configuring Dimension Filters
 
 A dimension filter provides filtering for a report. In SQL-land, this is the `WHERE` clause.
@@ -271,6 +289,20 @@ my_metric = ActiveReporting::Metric.new(
 
 `order_by_dimension` - Allows you to set the ordering of the results based on a dimension label. (Examples: `{author: :desc}`, `{sales_ref: :asc}`)
 
+For those using Postgres, you can take advantage of implicit hierarchies in `datetime` columns, as mentioned above:
+
+```ruby
+class UserFactModel < ActiveReporting::FactModel
+  dimension :created_at
+end
+
+my_metric = ActiveReporting::Metric.new(
+  :my_total,
+  fact_model: UserFactModel,
+  dimensions: [{ created_at: :quarter } ]
+)
+```
+
 ## ActiveReporting::Report
 
 A `Report` takes an `ActiveReporting::Metric` and ties everything together. It is responsible for building and executing the query to generate a result. The result is an simple array of hashing.
@@ -279,7 +311,7 @@ A `Report` takes an `ActiveReporting::Metric` and ties everything together. It i
 metric = ActiveReporting::Metric.new(
   :order_count,
   fact_model: OrderFactModel,
-  dimension: [:sales_rep],
+  dimensions: [:sales_rep],
   dimension_filter: {months_ago: 1}
 )
 
@@ -302,7 +334,7 @@ A `Report` may also take additional arguments to merge with the `Metric`'s infor
 metric = ActiveReporting::Metric.new(
   :order_count,
   fact_model: OrderFactModel,
-  dimension: [:sales_rep],
+  dimensions: [:sales_rep],
   dimension_filter: {months_ago: 1}
 )
 
@@ -331,6 +363,11 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Testing
+
+You can run the test suite using `rake test`. To test against a particular database, you'll need to set the
+appropriate `DB` environment variable, e.g. `DB=pg rake test`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/active_reporting. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
@@ -339,4 +376,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/active_reporting/dimension.rb
+++ b/lib/active_reporting/dimension.rb
@@ -1,5 +1,7 @@
 module ActiveReporting
   class Dimension
+    TYPES = { degenerate: :degenerate,
+              standard: :standard }.freeze
     attr_reader :name
 
     # @param model [ActiveRecord::Base]
@@ -19,12 +21,23 @@ module ActiveReporting
     # @return [Symbol]
     def type
       @type ||= if model.column_names.include?(@name)
-                  :degenerate
+                  TYPES[:degenerate]
                 elsif association
-                  :standard
+                  TYPES[:standard]
                 else
                   raise UnknownDimension, "Dimension '#{@name}' not found on fact model '#{@fact_model}'"
                 end
+    end
+
+    # Whether the dimension is a datetime column
+    #
+    # @return [Boolean]
+    def datetime?
+      @datetime ||= if type == TYPES[:degenerate]
+                      model.column_for_attribute(@name).type == :datetime
+                    else
+                      false
+                    end
     end
 
     # Tells if the dimension is hierarchical

--- a/test/active_reporting/dimension_test.rb
+++ b/test/active_reporting/dimension_test.rb
@@ -6,7 +6,7 @@ class ActiveReporting::DimensionTest < ActiveSupport::TestCase
     assert_equal :standard, subject.type
 
     subject = ActiveReporting::Dimension.new(FigureFactModel, name: :kind)
-    assert_equal :degenerate, subject.type
+    assert_equal ActiveReporting::Dimension::TYPES[:degenerate], subject.type
 
     subject = ActiveReporting::Dimension.new(ReleaseDateFactModel, name: :released_on)
     assert_equal :standard, subject.type

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -31,4 +31,19 @@ class ActiveReporting::ReportTest < Minitest::Test
     refute data.empty?
     assert data.all? { |r| r.key?('a_metric') }
   end
+
+  def test_report_runs_with_a_date_grouping
+    if ENV['DB'] == 'pg'
+      metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])
+      report = ActiveReporting::Report.new(metric)
+      data = report.run
+      assert data.all? { |r| r.key?('created_at_month') }
+      assert data.size == 5
+    else
+      assert_raises ActiveReporting::InvalidDimensionLabel do
+        metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])
+        report = ActiveReporting::Report.new(metric)
+      end
+    end
+  end
 end

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -15,19 +15,20 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
 
     @user_profile_dimension                       = ActiveReporting::Dimension.new(UserFactModel, name: :profile)
     @user_fact_model_default_label                = UserFactModel.dimension_label
+    @user_dimension                               = ActiveReporting::Dimension.new(UserFactModel, name: :created_at)
   end
 
-  def test_forign_key_is_name_if_degenerate
+  def test_foreign_key_is_name_if_degenerate
     subject = ActiveReporting::ReportingDimension.new(@figure_kind_dimension)
     assert_equal 'kind', subject.foreign_key
   end
 
-  def test_forign_key_for_belongs_to_relation_if_standard
+  def test_foreign_key_for_belongs_to_relation_if_standard
     subject = ActiveReporting::ReportingDimension.new(@figure_series_dimension)
     assert_equal 'series_id', subject.foreign_key
   end
 
-  def test_forign_key_for_has_one_relation_if_standard
+  def test_foreign_key_for_has_one_relation_if_standard
     subject = ActiveReporting::ReportingDimension.new(@user_profile_dimension)
     assert_equal 'user_id', subject.foreign_key
   end
@@ -76,10 +77,30 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
     end
   end
 
-  def test_label_can_only_be_passed_in_if_dimension_is_herarchical
-    refute @figure_series_dimension.type == :herarchical
+  def test_label_can_be_passed_in_if_dimension_is_herarchical
+    refute @figure_series_dimension.hierarchical?
     assert_raises ActiveReporting::InvalidDimensionLabel do
       ActiveReporting::ReportingDimension.new(@figure_series_dimension, label: :foo)
+    end
+  end
+
+  def test_label_can_be_passed_in_if_dimension_is_datetime
+    refute @user_dimension.hierarchical?
+    assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
+    if ENV['DB'] == 'pg'
+      ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
+    else
+      assert_raises ActiveReporting::InvalidDimensionLabel do
+        ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
+      end
+    end
+  end
+
+  def test_invalid_label_cannot_be_passed_in_if_dimension_is_datetime
+    refute @user_dimension.hierarchical?
+    assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
+    assert_raises ActiveReporting::InvalidDimensionLabel do
+      ActiveReporting::ReportingDimension.new(@user_dimension, label: :foo)
     end
   end
 

--- a/test/fact_models.rb
+++ b/test/fact_models.rb
@@ -35,6 +35,7 @@ end
 
 class UserFactModel < ActiveReporting::FactModel
   default_dimension_label :username
+  dimension :created_at
 end
 
 class SaleFactModel < ActiveReporting::FactModel

--- a/test/seed.rb
+++ b/test/seed.rb
@@ -4,10 +4,12 @@ end
 
 (1..5).each do |i|
   user = User.create!(
+    created_at: Time.now - i.months,
     username: "user_#{i}"
   )
 
   Profile.create!(
+    created_at: Time.now - i.months,
     user: user,
     favorite_pokemon: 'Pikachu'
   )


### PR DESCRIPTION
Thanks for creating such a useful gem. We are so pleased to have come across it -- all the other "reporting" gems for ActiveRecord fall short in our view.

This PR reflects one of the modifications we had to make to the gem for our app. We have some serious technical debt, and were not in a position to modify our database schema to create a date dimension table. As a result, we couldn't utilize date hierarchies as described in this gem's API. As Postgres users, we had to instead use the DATE_TRUNC function.

In order to do that, we created implicit hierarchies. Thus, if a database column is a `datetime` column and declared as a dimension in a `FactModel`, you can treat it as if it had a hierarchy in a`Metric`:

```ruby
class SomeFactModel < ActiveReporting::FactModel
  dimension :created_at
end

metric = ActiveReporting::Metric.new(:metric, fact_model: SomeFactModel, dimensions: [{created_at: :day}])
```
When utilizing an implicit hierarchy, the data is returned under the key name concatenated with `_<hierarchy>` (e.g., `created_at_day`, `created_at_quarter`, etc.)  Because we are not savvy in non-Postgres, we limited this feature to Postgres. (The gem will raise an error for other DBs.) 

Would love to know if this is a feature you think is helpful to your project, as well as any other feedback you might have to improve this feature for ActiveReporting. (We have a few other changes we have made as well, which we will submit as a PR once they are further tested.)