### PR TITLE
Add aggregate expression FactModel feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,21 @@ class TicketFactModel < ActiveReporting::FactModel
 end
 ```
 
+## Configuring Aggregate Expressions
+
+If you need more granular control over any aggregate function (e.g., `SUM`, `COUNT`, `AVG`, etc.), you can declare an [aggregate expression](https://www.postgresql.org/docs/8.2/static/functions-aggregate.html) in the fact model. This use case can arise if you need more granular control over the results of an aggregate function specified in an `ActiveReporting::Metric`.
+
+The declaration takes the raw SQL expression that you want to use:
+
+```ruby
+class TicketFactModel < ActiveReporting::FactModel
+  aggregate_expression :my_custom_expression,
+                       "CASE WHEN name = 'foo' THEN 5 END"
+end
+```
+
+Whatever expression you choose, it is important to remember that aggregate functions consider all non-`null` results -- so anything you want to exclude should compute to `null`.
+
 ## ActiveReporting::Metric
 
 A `Metric` is the basic building block used to describe a question you want to answer. At minimum, a metric needs a name, a fact table and an aggregate. You can expand a metric further by including dimensions and dimension filters.
@@ -283,7 +298,7 @@ my_metric = ActiveReporting::Metric.new(
 
 `fact_model` - An `ActiveReporting::FactModel` class
 
-`aggregate` - The SQL aggregate used to calculate the metric. Supported aggregates include count, max, min, avg, and sum. (Default: `:count`)
+`aggregate` - The SQL aggregate used to calculate the metric. Supported aggregates include count, max, min, avg, and sum. (Default: `:count`.) You can also specify an aggregate expression (discussed above) if you defined one in your fact model: `aggregate: { count: :my_custom_expression }` or `aggregate: { sum: :my_custom_expression }`-- and the expression declared in the fact model will be used by the database in the function (e.g., `SUM(CASE WHEN name = 'foo' THEN 1 END)`).
 
 `dimensions` - An array of dimensions used for the metric. When given just a symbol, the default dimension label will be used for the dimension. You may specify a hierarchy level by using a hash. (Examples: `[:sales_rep, {order_date: :month}]`)
 

--- a/lib/active_reporting.rb
+++ b/lib/active_reporting.rb
@@ -34,11 +34,12 @@ module ActiveReporting
     klass.constantize.lookup(name)
   end
 
-  BadMetricLookupClass    = Class.new(StandardError)
-  InvalidDimensionLabel   = Class.new(StandardError)
-  RansackNotAvailable     = Class.new(StandardError)
-  UnknownAggregate        = Class.new(StandardError)
-  UnknownDimension        = Class.new(StandardError)
-  UnknownDimensionFilter  = Class.new(StandardError)
-  UnknownMetric           = Class.new(StandardError)
+  BadMetricLookupClass       = Class.new(StandardError)
+  InvalidDimensionLabel      = Class.new(StandardError)
+  RansackNotAvailable        = Class.new(StandardError)
+  UnknownAggregate           = Class.new(StandardError)
+  UnknownAggregateExpression = Class.new(StandardError)
+  UnknownDimension           = Class.new(StandardError)
+  UnknownDimensionFilter     = Class.new(StandardError)
+  UnknownMetric              = Class.new(StandardError)
 end

--- a/lib/active_reporting/fact_model.rb
+++ b/lib/active_reporting/fact_model.rb
@@ -96,6 +96,30 @@ module ActiveReporting
       @dimensions[name.to_sym] = Dimension.new(self, name: name)
     end
 
+    # Declares an aggregate expression that can be used in a Metric. See, e.g.:
+    # https://www.postgresql.org/docs/8.2/static/functions-aggregate.html
+    #
+    # @param name [String, Symbol]
+    # @param expression [String] SQL expression
+    #
+    # @example
+    #   class FooFactModel < ActiveReporting::FactModel
+    #     aggregate_expression :bar_is_5, "CASE WHEN bar = '5' THEN 1 END"
+    #   end
+    #
+    #   m = ActiveReporting::Metric.new(:bar_count,
+    #                                   fact_model: FooFactModel,
+    #                                   aggregate: { count: :bar_is_5 } )
+    #
+    def self.aggregate_expression(name, expression)
+      @aggregate_expressions ||= {}
+      @aggregate_expressions[name.to_sym] = expression
+    end
+
+    def self.aggregate_expressions
+      @aggregate_expressions || {}
+    end
+
     # Returns a hash of dimension label to callback mappings
     #
     # @return [Hash]

--- a/lib/active_reporting/metric.rb
+++ b/lib/active_reporting/metric.rb
@@ -7,7 +7,14 @@ module ActiveReporting
   class Metric
     extend Forwardable
     def_delegators :@fact_model, :model
-    attr_reader :fact_model, :name, :dimensions, :dimension_filter, :aggregate, :metric_filter, :order_by_dimension
+    attr_reader :fact_model,
+                :name,
+                :dimensions,
+                :dimension_filter,
+                :aggregate,
+                :aggregate_expression,
+                :metric_filter,
+                :order_by_dimension
 
     def initialize(
       name,
@@ -21,10 +28,10 @@ module ActiveReporting
       @name               = name.to_sym
       @fact_model         = fact_model
       @dimension_filter   = dimension_filter
-      @aggregate          = determin_aggregate(aggregate.to_sym)
       @metric_filter      = metric_filter
       @dimensions         = ReportingDimension.build_from_dimensions(@fact_model, Array(dimensions))
       @order_by_dimension = order_by_dimension
+      validate_aggregate(aggregate)
       check_dimension_filter
     end
 
@@ -43,9 +50,18 @@ module ActiveReporting
       end
     end
 
-    def determin_aggregate(agg)
-      raise UnknownAggregate, "Unknown aggregate '#{agg}'" unless AGGREGATES.include?(agg)
-      @aggregate = agg
+    def validate_aggregate(agg)
+      agg_name, expr = agg.is_a?(Hash) ? Array(agg).flatten : [agg.to_sym, nil]
+      raise UnknownAggregate, "Unknown aggregate '#{agg_name}'" unless AGGREGATES.include?(agg_name)
+      validate_agg_expression(expr) if expr
+      @aggregate = agg_name
+      @aggregate_expression = @fact_model.aggregate_expressions[expr]
+    end
+
+    def validate_agg_expression(expr)
+      return if @fact_model.aggregate_expressions[expr]
+      raise UnknownAggregateExpression,
+            "Aggregate expression '#{expr}' not defined in '#{@fact_model.name}'"
     end
   end
 end

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -78,9 +78,9 @@ module ActiveReporting
     def select_aggregate
       case @metric.aggregate
       when :count
-        'COUNT(*)'
+        "COUNT(#{@metric.aggregate_expression || '*'})"
       else
-        "#{@metric.aggregate.to_s.upcase}(#{fact_model.measure})"
+        "#{@metric.aggregate.to_s.upcase}(#{@metric.aggregate_expression || fact_model.measure})"
       end
     end
 

--- a/test/active_reporting/metric_test.rb
+++ b/test/active_reporting/metric_test.rb
@@ -45,4 +45,12 @@ class ActiveReporting::MetricTest < Minitest::Test
     assert metric.order_by_dimension.is_a?(Hash)
     assert_equal({:kind => :asc}, metric.order_by_dimension)
   end
+
+  def test_metric_raises_when_using_undefined_expression
+    assert_raises ActiveReporting::UnknownAggregateExpression do
+      ActiveReporting::Metric.new(
+        :a, fact_model: FigureFactModel, dimensions: [:kind], aggregate: { sum: :foo }
+      )
+    end
+  end
 end

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -42,7 +42,7 @@ class ActiveReporting::ReportTest < Minitest::Test
     report = ActiveReporting::Report.new(metric)
     data = report.run
     data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
-      assert d['a_metric'].zero?
+      assert d['a_metric'].to_i == 0
     end
     assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552)
   end
@@ -56,7 +56,7 @@ class ActiveReporting::ReportTest < Minitest::Test
     )
     report = ActiveReporting::Report.new(metric)
     data = report.run
-    assert data.all? { |r| r['a_metric'].zero? }
+    assert data.all? { |r| r['a_metric'].to_i == 0 }
   end
 
   def test_report_runs_with_a_date_grouping
@@ -84,7 +84,7 @@ class ActiveReporting::ReportTest < Minitest::Test
     report = ActiveReporting::Report.new(metric)
     data = report.run
     data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
-      assert d['a_metric'].zero?
+      assert d['a_metric'].to_i == 0
     end
     assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552 * 20)
   end

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -32,6 +32,33 @@ class ActiveReporting::ReportTest < Minitest::Test
     assert data.all? { |r| r.key?('a_metric') }
   end
 
+  def test_report_runs_aggregate_with_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { count: :kind_is_card }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
+      assert d['a_metric'].zero?
+    end
+    assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552)
+  end
+
+  def test_report_count_is_zero_with_aggregate_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { count: :kind_is_foo }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    assert data.all? { |r| r['a_metric'].zero? }
+  end
+
   def test_report_runs_with_a_date_grouping
     if ENV['DB'] == 'pg'
       metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])
@@ -45,5 +72,20 @@ class ActiveReporting::ReportTest < Minitest::Test
         report = ActiveReporting::Report.new(metric)
       end
     end
+  end
+
+  def test_report_sum_is_520_x_20_with_aggregate_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { sum: :return_20_when_card }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
+      assert d['a_metric'].zero?
+    end
+    assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552 * 20)
   end
 end

--- a/test/fact_models.rb
+++ b/test/fact_models.rb
@@ -2,6 +2,10 @@ class FigureFactModel < ActiveReporting::FactModel
   dimension :kind
   dimension :series
 
+  aggregate_expression :kind_is_card, "CASE WHEN kind = 'amiibo card' THEN 1 END"
+  aggregate_expression :kind_is_foo, "CASE WHEN kind = 'foo' THEN 1 END"
+  aggregate_expression :return_20_when_card, "CASE WHEN kind = 'amiibo card' THEN 20 ELSE 0 END"
+
   dimension_filter :kind_is, ->(k) { where(kind: k) }
 end
 


### PR DESCRIPTION
We needed more granular control over the aggregate function results, as our data was not perfectly modeled to get what we wanted. So we added the `aggregate_expression` declaration to the fact model API, which allowed us to mix in some SQL when needed. Works like so:

```ruby
# Assume a `Case` model. Has an expected_recovery column for what might be obtained,
# expected_hours for how many hours expected to be worked, and a `type` column that
# can be "pro bono" (free), "contingency" (take 30% of expected_recovery),  or "hourly"
# (expected hours times $300).
#
class CaseFactModel < ActiveReporting::FactModel
  aggregate_expression(
    :expected_money_agg_exp,
    "CASE WHEN type = 'pro bono' THEN 0 " \
    "WHEN type = 'contingency' THEN expected_recovery * 0.3 " \
    "WHEN type = 'hourly' THEN expected_hours * 300 END"
  )
end

metric = ActiveReporting::Metric.new(
  :my_metric,
  fact_model: CaseFactModel,
  aggregate: { sum: :expected_money_agg_exp }
)
``` 

Of course, Metric still works as it previous did as well. We have been using this feature in our production app with no issues.

Hope you think this is something that would be constructive to your delightful gem! As always, open to any feedback.