### PR TITLE
Rails 4.1 backwards compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
   - RAILS=4-2 DB=sqlite
   - RAILS=4-2 DB=pg
   - RAILS=4-2 DB=mysql
+  - RAILS=4-1 DB=pg
+  - RAILS=4-1 DB=mysql
+  - RAILS=4-1 DB=sqlite
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   - RAILS=4-2 DB=sqlite
   - RAILS=4-2 DB=pg
   - RAILS=4-2 DB=mysql
+  - RAILS=4-1 DB=sqlite
   - RAILS=4-1 DB=pg
   - RAILS=4-1 DB=mysql
-  - RAILS=4-1 DB=sqlite
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,21 @@ rails = ENV['RAILS'] || '5-2'
 db = ENV['DB'] || 'sqlite'
 
 case rails
+when '4-1'
+  gem 'activerecord', '~> 4.1.0'
 when '4-2'
   gem 'activerecord', '~> 4.2.0'
+when '5-1'
+  gem 'activerecord', '~> 5.1.0'
+else
+  gem 'activerecord', '~> 5.2.0'
+end
+
+if rails == "4-1" || rails == "4-2"
   if ENV['DB'] == 'pg'
     gem 'pg', '~> 0.18'
   end
   if ENV['DB'] == 'mysql'
     gem 'mysql2', '~> 0.3.18'
   end
-when '5-1'
-  gem 'activerecord', '~> 5.1.0'
-else
-  gem 'activerecord', '~> 5.2.0'
 end

--- a/active_reporting.gemspec
+++ b/active_reporting.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'activerecord', '>= 4.2.0'
-  spec.add_dependency 'activesupport', '>= 4.2.0'
+  spec.add_dependency 'activerecord', '>= 4.1.0'
+  spec.add_dependency 'activesupport', '>= 4.1.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
the test suite is passing which was a little surprising. I understand not supporting this officially, but it would be nice to have the option. 

Noting the change to the gemfile, the versions listed for the pg and mysql gems were fine with 4.1 and 4.2 so thats why i wrote it that way. I felt it was dryer than having two identical conditions in the case statement. Let me know if you want me to change it.