### PR TITLE
Testing updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3.8
   - 2.4.6
   - 2.5.5
+  - 2.6.3
 env:
   - RAILS=5-2 DB=sqlite
   - RAILS=5-2 DB=pg
@@ -14,6 +15,9 @@ env:
   - RAILS=4-2 DB=sqlite
   - RAILS=4-2 DB=pg
   - RAILS=4-2 DB=mysql
+  - RAILS=4-1 DB=sqlite
+  - RAILS=4-1 DB=pg
+  - RAILS=4-1 DB=mysql
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ env:
   - RAILS=4-2 DB=sqlite
   - RAILS=4-2 DB=pg
   - RAILS=4-2 DB=mysql
-exclude:
-  - rvm: 2.4.6
-    env: RAILS=6-0 DB=mysql
-  - rvm: 2.4.6
-    env: RAILS=6-0 DB=pg
-  - rvm: 2.4.6
-    env: RAILS=6-0 DB=sqlite
+matrix:
+  exclude:
+    - rvm: 2.4.6
+      env: RAILS=6-0 DB=mysql
+    - rvm: 2.4.6
+      env: RAILS=6-0 DB=pg
+    - rvm: 2.4.6
+      env: RAILS=6-0 DB=sqlite
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+addons:
+  postgresql: "9.6"
 rvm:
   - 2.4.6
   - 2.5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
 env:
   - RAILS=5-2 DB=sqlite
   - RAILS=5-2 DB=pg

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ rvm:
   - 2.5.5
   - 2.6.3
 env:
-  - RAILS=5-2 DB=sqlite
-  - RAILS=5-2 DB=pg
-  - RAILS=5-2 DB=mysql
-  - RAILS=5-1 DB=sqlite
-  - RAILS=5-1 DB=pg
-  - RAILS=5-1 DB=mysql
-  - RAILS=4-2 DB=sqlite
-  - RAILS=4-2 DB=pg
-  - RAILS=4-2 DB=mysql
+  #- RAILS=5-2 DB=sqlite
+  #- RAILS=5-2 DB=pg
+  #- RAILS=5-2 DB=mysql
+  #- RAILS=5-1 DB=sqlite
+  #- RAILS=5-1 DB=pg
+  #- RAILS=5-1 DB=mysql
+  #- RAILS=4-2 DB=sqlite
+  #- RAILS=4-2 DB=pg
+  #- RAILS=4-2 DB=mysql
   - RAILS=4-1 DB=sqlite
   - RAILS=4-1 DB=pg
   - RAILS=4-1 DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.3
 env:
-  #- RAILS=5-2 DB=sqlite
-  #- RAILS=5-2 DB=pg
-  #- RAILS=5-2 DB=mysql
-  #- RAILS=5-1 DB=sqlite
-  #- RAILS=5-1 DB=pg
-  #- RAILS=5-1 DB=mysql
-  #- RAILS=4-2 DB=sqlite
-  #- RAILS=4-2 DB=pg
-  #- RAILS=4-2 DB=mysql
-  - RAILS=4-1 DB=sqlite
-  - RAILS=4-1 DB=pg
-  - RAILS=4-1 DB=mysql
+  - RAILS=5-2 DB=sqlite
+  - RAILS=5-2 DB=pg
+  - RAILS=5-2 DB=mysql
+  - RAILS=5-1 DB=sqlite
+  - RAILS=5-1 DB=pg
+  - RAILS=5-1 DB=mysql
+  - RAILS=4-2 DB=sqlite
+  - RAILS=4-2 DB=pg
+  - RAILS=4-2 DB=mysql
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ env:
   - RAILS=4-2 DB=sqlite
   - RAILS=4-2 DB=pg
   - RAILS=4-2 DB=mysql
+exclude:
+  - rvm: 2.4.6
+    env: RAILS=6-0 DB=mysql
+  - rvm: 2.4.6
+    env: RAILS=6-0 DB=pg
+  - rvm: 2.4.6
+    env: RAILS=6-0 DB=sqlite
 before_script:
   - psql -c 'create database active_reporting_test;' -U postgres
   - mysql -e 'create database active_reporting_test collate utf8_general_ci;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.5.5
   - 2.6.3
 env:
+  - RAILS=6-0 DB=sqlite
+  - RAILS=6-0 DB=pg
+  - RAILS=6-0 DB=mysql
   - RAILS=5-2 DB=sqlite
   - RAILS=5-2 DB=pg
   - RAILS=5-2 DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,24 @@ rails = ENV['RAILS'] || '5-2'
 db = ENV['DB'] || 'sqlite'
 
 case rails
+when '4-1'
+  gem 'activerecord', '~> 4.1.0'
 when '4-2'
   gem 'activerecord', '~> 4.2.0'
-  if ENV['DB'] == 'pg'
-    gem 'pg', '~> 0.18'
-  end
-  if ENV['DB'] == 'mysql'
-    gem 'mysql2', '~> 0.3.18'
-  end
 when '5-1'
   gem 'activerecord', '~> 5.1.0'
-else
+when '5-2'
   gem 'activerecord', '~> 5.2.0'
+end
+
+case rails
+when '4-2' || '4-1'
+  case ENV['DB']
+  when 'pg'
+    gem 'pg', '~> 0.18'
+  when 'mysql'
+    gem 'mysql2', '~> 0.3.18'
+  when 'sqlite'
+    gem 'sqlite3', '~> 1.3.0'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ when '5-1'
   gem 'activerecord', '~> 5.1.0'
 when '5-2'
   gem 'activerecord', '~> 5.2.0'
+when '6-0'
+  gem 'activerecord', '6.0.0.rc1'
 end
 
 case rails

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ when '5-2'
 end
 
 case rails
-when '4-2' || '4-1'
+when '4-2'
   case ENV['DB']
   when 'pg'
     gem 'pg', '~> 0.18'
@@ -28,4 +28,14 @@ when '4-2' || '4-1'
   when 'sqlite'
     gem 'sqlite3', '~> 1.3.0'
   end
+when '4-1'
+  case ENV['DB']
+  when 'pg'
+    gem 'pg', '0.11.0'
+  when 'mysql'
+    gem 'mysql2', '0.3.13'
+  when 'sqlite'
+    gem 'sqlite3', '1.3.6'
+  end
+
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ rails = ENV['RAILS'] || '5-2'
 db = ENV['DB'] || 'sqlite'
 
 case rails
-when '4-1'
-  gem 'activerecord', '~> 4.1.0'
 when '4-2'
   gem 'activerecord', '~> 4.2.0'
 when '5-1'
@@ -28,14 +26,4 @@ when '4-2'
   when 'sqlite'
     gem 'sqlite3', '~> 1.3.0'
   end
-when '4-1'
-  case ENV['DB']
-  when 'pg'
-    gem 'pg', '0.11.0'
-  when 'mysql'
-    gem 'mysql2', '0.3.13'
-  when 'sqlite'
-    gem 'sqlite3', '1.3.6'
-  end
-
 end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ActiveReporting implements various terminology used in Relational Online Analyti
 
 ActiveReporting officially supports MySQL, PostgreSQL, and SQLite.
 
-ActiveReporting officially supports Ruby 2.3 and later. Other versions may work, but are not supported.
+ActiveReporting officially supports Ruby 2.4 and later. Other versions may work, but are not supported.
 
 ActiveReporting officially supports Rails 4.2, 5.1, and 5.2. Other versions may work, but are not supported.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ ActiveReporting implements various terminology used in Relational Online Analyti
 
 ActiveReporting officially supports MySQL, PostgreSQL, and SQLite.
 
-ActiveReporting officially supports Ruby 2.3, 2.4, and 2.5.
+ActiveReporting officially supports Ruby 2.3 and later. Other versions may work, but are not supported.
 
-ActiveReporting officially supports Rails 4.2, 5.1, and 5.2.
+ActiveReporting officially supports Rails 4.2, 5.1, and 5.2. Other versions may work, but are not supported.
 
 ## Installation
 

--- a/active_reporting.gemspec
+++ b/active_reporting.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'activerecord', '>= 4.2.0'
-  spec.add_dependency 'activesupport', '>= 4.2.0'
+  spec.add_dependency 'activerecord'
+  spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
- Loosened the active record requirements. Only the currently supported Rails versions are supported still in this gem.
- Test against Rails 6.0RC
- Test against the currently supported Rubies. The gem will still allow for Ruby 2.3, but is not officially supported.