### PR TITLE
Fix “to_hash” deprecation warning

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -36,7 +36,7 @@ module ActiveReporting
     private ######################################################################
 
     def build_data
-      @data = model.connection.exec_query(statement.to_sql).to_hash
+      @data = model.connection.exec_query(statement.to_sql).to_a
       apply_dimension_callbacks
       @data
     end


### PR DESCRIPTION
“DEPRECATION WARNING: `ActiveRecord::Result#to_hash` has been renamed to `to_a`. `to_hash` is deprecated and will be removed in Rails 6.1”

Changing the only instance of “to_hash” to “to_a”.