### PR TITLE
add support to implicit hierarchical on datetime columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ class PhoneFactModel < ActiveReporting::FactModel
 end
 ```
 
-### Implicit hierarchies with datetime columns (PostgreSQL support only)
+### Implicit hierarchies with datetime columns
 
 The fastest approach to group by certain date metrics is to create so-called "date dimensions". For
 those Postgres users that are restricted from organizing their data in this way, Postgres provides
-a way to group by `datetime` column data on the fly using the `date_trunc` function.
+a way to group by `datetime` column data on the fly using the [`date_trunc` function](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC). On Mysql this can be done using [Date and Time Functions](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html).
 
 To use, declare a datetime dimension on a fact model as normal:
 
@@ -233,7 +233,24 @@ class UserFactModel < ActiveReporting::FactModel
 end
 ```
 
-When creating a metric, ActiveReporting will recognize implicit hierarchies for this dimension. The hierarchies correspond to the [values](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC) supported by PostgreSQL. (See example under the metric section, below.)
+When creating a metric, ActiveReporting will recognize implicit hierarchies for this dimension.
+The valid values are:
+
+- microseconds
+- milliseconds
+- second
+- minute
+- hour
+- day
+- week
+- month
+- quarter
+- year
+- decade
+- century
+- millennium
+
+(See example under the metric section, below.)
 
 *NOTE*: PRs welcomed to support this functionality in other databases.
 

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -4,7 +4,7 @@ require 'forwardable'
 module ActiveReporting
   class ReportingDimension
     extend Forwardable
-    SUPPORTED_DBS = %w[PostgreSQL PostGIS].freeze
+    SUPPORTED_DBS = %w[PostgreSQL PostGIS Mysql2].freeze
     # Values for the Postgres `date_trunc` method.
     # See https://www.postgresql.org/docs/10/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
     DATETIME_HIERARCHIES = %i[microseconds milliseconds second minute hour day week month quarter year decade
@@ -145,8 +145,51 @@ module ActiveReporting
     end
 
     def degenerate_select_fragment
-      return "DATE_TRUNC('#{@label}', #{model.quoted_table_name}.#{name}) AS #{name}_#{@label}" if datetime?
+      if datetime?
+        if model.connection.adapter_name == "Mysql2"
+          return degenerate_select_fragment_mysql
+        else # Postgress
+          return degenerate_select_fragment_postgress
+        end
+      end
       "#{model.quoted_table_name}.#{name}"
+    end
+
+    def degenerate_select_fragment_postgress
+      "DATE_TRUNC('#{@label}', #{model.quoted_table_name}.#{name}) AS #{name}_#{@label}"
+    end
+
+    def degenerate_select_fragment_mysql
+      field = "#{model.quoted_table_name}.#{model.connection.quote_column_name(name)}"
+      modifier = case @label.to_sym
+      when :microseconds
+        "MICROSECOND(#{field})"
+      when :milliseconds
+        "MICROSECOND(#{field}) DIV 1000"
+      when :second
+        "SECOND(#{field})"
+      when :minute
+        "MINUTE(#{field})"
+      when :hour
+        "HOUR(#{field})"
+      when :day
+        "DAY(#{field})"
+      when :week
+        "WEEKDAY(#{field})"
+      when :month
+        "MONTH(#{field})"
+      when :quarter
+        "QUARTER(#{field})"
+      when :year
+        "YEAR(#{field})"
+      when :decade
+        "YEAR(#{field}) DIV 10"
+      when :century
+        "YEAR(#{field}) DIV 100"
+      when :millennium
+        "YEAR(#{field}) DIV 1000"
+      end
+      "#{modifier} AS #{name}_#{@label}"
     end
 
     def identifier_fragment

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -33,7 +33,7 @@ class ActiveReporting::ReportTest < Minitest::Test
   end
 
   def test_report_runs_with_a_date_grouping
-    if ENV['DB'] == 'pg'
+    if ['pq','mysql'].include?(ENV['DB'])
       metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])
       report = ActiveReporting::Report.new(metric)
       data = report.run

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -33,7 +33,7 @@ class ActiveReporting::ReportTest < Minitest::Test
   end
 
   def test_report_runs_with_a_date_grouping
-    if ['pq','mysql'].include?(ENV['DB'])
+    if ['pg','mysql'].include?(ENV['DB'])
       metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])
       report = ActiveReporting::Report.new(metric)
       data = report.run

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -106,7 +106,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
   def test_label_can_be_passed_in_if_dimension_is_datetime
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
-    if ENV['DB'] == 'pg'
+    if ['pq','mysql'].include?(ENV['DB'])
       ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -106,7 +106,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
   def test_label_can_be_passed_in_if_dimension_is_datetime
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
-    if ['pq','mysql'].include?(ENV['DB'])
+    if ['pg','mysql'].include?(ENV['DB'])
       ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do


### PR DESCRIPTION
I found a solution to group by date dimension hierarchies on mysql database. To achieve this i changed the `ReportingDimension# degenerate_select_fragment` to use [Mysql Date and Time Functions] (https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html ) to create a select fragment with same postgress `date_trunc` behavior.

The options on mysql are not exactly the same of postgress, so i decide to support all, and only, postgress `date_trunc` values. It probably will be enough for mysql users and that way i keep the ActiveReport API consistent.

Please let me know what you thing, and any feedback about the code will be apreciate.