### PR TITLE
add drill down and up for datetime columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-* Support to implicit hierarchical on datetime columns in MySQL (#33) - *germantom*
+* Support to implicit hierarchical on datetime columns in MySQL (#33) - *germanotm*
 
 ## 0.5.1 (2020-06-31)
 

--- a/lib/active_reporting/dimension.rb
+++ b/lib/active_reporting/dimension.rb
@@ -30,13 +30,6 @@ module ActiveReporting
                 end
     end
 
-    # Whether the dimension is a datetime column
-    #
-    # @return [Boolean]
-    def datetime?
-      @datetime ||= type == TYPES[:degenerate] && model.column_for_attribute(@name).type == :datetime
-    end
-
     # Tells if the dimension is hierarchical
     #
     # @return [Boolean]

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -145,7 +145,7 @@ module ActiveReporting
         callback = dimension.label_callback
         next unless callback
         @data.each do |hash|
-          hash[dimension.name.to_s] = callback.call(hash[dimension.name.to_s])
+          hash["#{dimension.name}_#{dimension.label}"] = callback.call(hash["#{dimension.name}_#{dimension.label}"])
         end
       end
     end

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -10,18 +10,23 @@ module ActiveReporting
     DATETIME_HIERARCHIES = %i[microseconds milliseconds second minute hour day week month quarter year decade
                               century millennium].freeze
     JOIN_METHODS = { joins: :joins, left_outer_joins: :left_outer_joins }.freeze
-    attr_reader :join_method
+    attr_reader :join_method, :label
 
-    def_delegators :@dimension, :name, :type, :klass, :association, :model, :hierarchical?, :datetime?
+    def_delegators :@dimension, :name, :type, :klass, :association, :model, :hierarchical?
 
     def self.build_from_dimensions(fact_model, dimensions)
       Array(dimensions).map do |dim|
-        dimension_name, label = dim.is_a?(Hash) ? Array(dim).flatten : [dim, nil]
+        dimension_name, options = dim.is_a?(Hash) ? Array(dim).flatten : [dim, nil]
         found_dimension = fact_model.dimensions[dimension_name.to_sym]
 
-        raise(UnknownDimension, "Dimension '#{dim}' not found on fact model '#{fact_model}'") if found_dimension.nil?
+        raise(UnknownDimension, "Dimension '#{dimension_name}' not found on fact model '#{fact_model}'") if found_dimension.nil?
 
-        new(found_dimension, **label_config(label))
+        # Ambiguous behavior with string option for degenerate and standard dimension
+        if !options.is_a?(Hash) && found_dimension.type == Dimension::TYPES[:degenerate]
+          warn "[DEPRECATION] direct use of implict hierarchies is deprecated. Please use `:datetime_drill` option instead."
+          options = { datetime_drill: options }
+        end
+        new(found_dimension, **label_config(options))
       end
     end
 
@@ -29,24 +34,28 @@ module ActiveReporting
     # the field on that dimension. With a hash you can
     # customize the name of the label
     #
-    # @param [Symbol|Hash] label
-    def self.label_config(label)
-      return { label: label } unless label.is_a?(Hash)
+    # @param [Symbol|Hash] options
+    def self.label_config(options)
+      unless options.is_a?(Hash)
+        return { label: options }
+      end
 
       {
-        label: label[:field],
-        label_name: label[:name],
-        join_method: label[:join_method]
+        label: options[:field],
+        label_name: options[:name],
+        join_method: options[:join_method],
+        datetime_drill: options[:datetime_drill]
       }
     end
 
     # @param dimension [ActiveReporting::Dimension]
     # @option label [Maybe<Symbol>] Hierarchical dimension to be used as a label
     # @option label_name [Maybe<Symbol|String>] Hierarchical dimension custom name
-    def initialize(dimension, label: nil, label_name: nil, join_method: nil)
+    def initialize(dimension, label: nil, label_name: nil, join_method: nil, datetime_drill: nil)
       @dimension = dimension
 
       determine_label_field(label)
+      determine_datetime_drill(datetime_drill)
       determine_label_name(label_name)
       determine_join_method(join_method)
     end
@@ -62,10 +71,8 @@ module ActiveReporting
     #
     # @return [Array]
     def select_statement(with_identifier: true)
-      return [degenerate_select_fragment] if type == Dimension::TYPES[:degenerate]
-
-      ss = ["#{label_fragment} AS #{model.connection.quote_column_name(@label_name)}"]
-      ss << "#{identifier_fragment} AS #{model.connection.quote_column_name("#{name}_identifier")}" if with_identifier
+      ss = ["#{label_fragment} AS #{label_fragment_alias}"]
+      ss << "#{identifier_fragment} AS #{identifier_fragment_alias}" if with_identifier && type == Dimension::TYPES[:standard]
       ss
     end
 
@@ -73,10 +80,8 @@ module ActiveReporting
     #
     # @return [Array]
     def group_by_statement(with_identifier: true)
-      return [degenerate_fragment] if type == Dimension::TYPES[:degenerate]
-
       group = [label_fragment]
-      group << identifier_fragment if with_identifier
+      group << identifier_fragment if with_identifier && type == Dimension::TYPES[:standard]
       group
     end
 
@@ -86,7 +91,6 @@ module ActiveReporting
     def order_by_statement(direction:)
       direction = direction.to_s.upcase
       raise "Ording direction should be 'asc' or 'desc'" unless %w[ASC DESC].include?(direction)
-      return "#{degenerate_fragment} #{direction}" if type == Dimension::TYPES[:degenerate]
       "#{label_fragment} #{direction}"
     end
 
@@ -101,14 +105,32 @@ module ActiveReporting
 
     def determine_label_field(label_field)
       @label = if label_field.present? && validate_hierarchical_label(label_field)
-                 label_field.to_sym
+                 type == Dimension::TYPES[:degenerate] ? name : label_field.to_sym
+               elsif type == Dimension::TYPES[:degenerate]
+                 name
                else
                  dimension_fact_model.dimension_label || Configuration.default_dimension_label
                end
     end
 
     def determine_label_name(label_name)
-      @label_name = label_name ? "#{name}_#{label_name}" : name
+
+      if label_name
+        @label_name = label_name
+      else
+        @label_name = name
+        @label_name += "_#{@label}" if (type == Dimension::TYPES[:standard] && @label != :name)
+        @label_name += "_#{@datetime_drill}" if @datetime_drill
+      end
+      @label_name
+    end
+
+    def determine_datetime_drill(datetime_drill)
+      return unless datetime_drill
+      validate_supported_database_for_datetime_hierarchies
+      validate_against_datetime_hierarchies(datetime_drill)
+      validate_label_is_datetime
+      @datetime_drill = datetime_drill
     end
 
     def determine_join_method(join_method)
@@ -122,13 +144,8 @@ module ActiveReporting
     end
 
     def validate_hierarchical_label(hierarchical_label)
-      if datetime?
-        validate_supported_database_for_datetime_hierarchies
-        validate_against_datetime_hierarchies(hierarchical_label)
-      else
-        validate_dimension_is_hierachical(hierarchical_label)
-        validate_against_fact_model_properties(hierarchical_label)
-      end
+      validate_dimension_is_hierachical(hierarchical_label)
+      validate_against_fact_model_properties(hierarchical_label)
       true
     end
 
@@ -149,70 +166,75 @@ module ActiveReporting
       raise InvalidDimensionLabel, "#{hierarchical_label} is not a valid datetime grouping label in #{name}"
     end
 
+    def validate_label_is_datetime
+      return if dimension_fact_model.model.column_for_attribute(@label).type == :datetime
+      raise InvalidDimensionLabel, "'#{@label}' is not a datetime column"
+    end
+
     def validate_against_fact_model_properties(hierarchical_label)
       return if dimension_fact_model.hierarchical_levels.include?(hierarchical_label.to_sym)
       raise InvalidDimensionLabel, "#{hierarchical_label} is not a hierarchical label in #{name}"
     end
 
-    def degenerate_fragment
-      return "#{name}_#{@label}" if datetime?
-      "#{model.quoted_table_name}.#{name}"
-    end
-
-    def degenerate_select_fragment
-      if datetime?
-        if model.connection.adapter_name == "Mysql2"
-          return degenerate_select_fragment_mysql
-        else # Postgress
-          return degenerate_select_fragment_postgress
-        end
+    def datetime_drill_label_fragment(select_statement)
+      if model.connection.adapter_name == "Mysql2"
+        datetime_drill_mysql(select_statement)
+      else # Postgress
+        datetime_drill_postgress(select_statement)
       end
-      "#{model.quoted_table_name}.#{name}"
     end
 
-    def degenerate_select_fragment_postgress
-      "DATE_TRUNC('#{@label}', #{model.quoted_table_name}.#{name}) AS #{name}_#{@label}"
+    def datetime_drill_postgress(select_statement)
+      "DATE_TRUNC('#{@datetime_drill}', #{select_statement})"
     end
 
-    def degenerate_select_fragment_mysql
-      field = "#{model.quoted_table_name}.#{model.connection.quote_column_name(name)}"
-      modifier = case @label.to_sym
+    def datetime_drill_mysql(select_statement)
+      case @datetime_drill.to_sym
       when :microseconds
-        "MICROSECOND(#{field})"
+        "MICROSECOND(#{select_statement})"
       when :milliseconds
-        "MICROSECOND(#{field}) DIV 1000"
+        "MICROSECOND(#{select_statement}) DIV 1000"
       when :second
-        "SECOND(#{field})"
+        "SECOND(#{select_statement})"
       when :minute
-        "MINUTE(#{field})"
+        "MINUTE(#{select_statement})"
       when :hour
-        "HOUR(#{field})"
+        "HOUR(#{select_statement})"
       when :day
-        "DAY(#{field})"
+        "DAY(#{select_statement})"
       when :week
-        "WEEKDAY(#{field})"
+        "WEEKDAY(#{select_statement})"
       when :month
-        "MONTH(#{field})"
+        "MONTH(#{select_statement})"
       when :quarter
-        "QUARTER(#{field})"
+        "QUARTER(#{select_statement})"
       when :year
-        "YEAR(#{field})"
+        "YEAR(#{select_statement})"
       when :decade
-        "YEAR(#{field}) DIV 10"
+        "YEAR(#{select_statement}) DIV 10"
       when :century
-        "YEAR(#{field}) DIV 100"
+        "YEAR(#{select_statement}) DIV 100"
       when :millennium
-        "YEAR(#{field}) DIV 1000"
+        "YEAR(#{select_statement}) DIV 1000"
       end
-      "#{modifier} AS #{name}_#{@label}"
     end
 
     def identifier_fragment
       "#{klass.quoted_table_name}.#{model.connection.quote_column_name(klass.primary_key)}"
     end
 
+    def identifier_fragment_alias
+      "#{model.connection.quote_column_name("#{name}_identifier")}"
+    end
+
     def label_fragment
-      "#{klass.quoted_table_name}.#{model.connection.quote_column_name(@label)}"
+      ss = "#{klass.quoted_table_name}.#{model.connection.quote_column_name(@label)}"
+      ss = datetime_drill_label_fragment(ss) if @datetime_drill
+      ss
+    end
+
+    def label_fragment_alias
+      "#{model.connection.quote_column_name(@label_name)}"
     end
 
     def dimension_fact_model

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -20,7 +20,7 @@ class ActiveReporting::ReportTest < Minitest::Test
     data   = report.run
 
     refute data.empty?
-    assert data.all? { |r| r['released_on'].to_s.match(/\AQ\d+/) }
+    assert data.all? { |r| r['released_on_quarter'].to_s.match(/\AQ\d+/) }
   end
 
   def test_report_runs_with_an_aggregate_other_than_count

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -36,12 +36,12 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
 
   def test_select_statement_is_just_column_if_degenerate
     subject = ActiveReporting::ReportingDimension.new(@figure_kind_dimension)
-    assert_equal ["#{Figure.quoted_table_name}.kind"], subject.select_statement
+    assert_equal ["#{Figure.quoted_table_name}.#{ActiveRecord::Base.connection.quote_column_name("kind")} AS #{ActiveRecord::Base.connection.quote_column_name("kind")}"], subject.select_statement
   end
 
   def test_select_statement_can_have_custom_label_name_if_standard
     custom_label_name = 'custom_label_name'
-    build_label_name = "platform_#{custom_label_name}"
+    build_label_name = "#{custom_label_name}"
     subject = ActiveReporting::ReportingDimension.new(
       @game_platform_dimension,
       label: :name,
@@ -73,7 +73,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
 
   def test_group_by_statement_is_just_column_if_degenerate
     subject = ActiveReporting::ReportingDimension.new(@figure_kind_dimension)
-    assert_equal ["#{Figure.quoted_table_name}.kind"], subject.group_by_statement
+    assert_equal ["#{Figure.quoted_table_name}.#{ActiveRecord::Base.connection.quote_column_name("kind")}"], subject.group_by_statement
   end
 
   def test_group_by_statement_can_include_identifier_if_standard
@@ -115,10 +115,10 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
     if ['pg','mysql'].include?(ENV['DB'])
-      ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
+      ActiveReporting::ReportingDimension.new(@user_dimension, datetime_drill: :year)
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do
-        ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
+        ActiveReporting::ReportingDimension.new(@user_dimension, datetime_drill: :year)
       end
     end
   end
@@ -133,7 +133,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
 
   def test_order_by_statement_is_dimensions_column_sql_snippet
     subject = ActiveReporting::ReportingDimension.new(@figure_kind_dimension)
-    assert_equal "#{Figure.quoted_table_name}.kind ASC", subject.order_by_statement(direction: :asc)
+    assert_equal "#{Figure.quoted_table_name}.#{ActiveRecord::Base.connection.quote_column_name("kind")} ASC", subject.order_by_statement(direction: :asc)
 
     subject = ActiveReporting::ReportingDimension.new(@figure_series_dimension)
     assert_equal "#{Series.quoted_table_name}.#{ActiveRecord::Base.connection.quote_column_name(@series_fact_model_default_label)} DESC", subject.order_by_statement(direction: :desc)


### PR DESCRIPTION
Closes #18 

I made the necessary changes to fully support datetime hierarchies. As discussed in  #18, the chosen approach was to add an option to dimension hash, so you may choose datetime hierarchy as needed.

```ruby
[:sales_rep, { order: { field: :created_at, datetime_drill: :month } }]
```

You suggest using the name `hierarchy` to this option, but this modifier will only modify the datetime column. In the example above, conceptually, the dimension is the Order, the hierarchy is Created_at, and the Month is a drill up operation over the datetime. What a drill operation should do is change the hierarchy of the selected dimension, but in the code is simpler to keep these datetime hierarchies implicit.
What we are really making is a drill operation, then I decide to keep the name datetime_drill over hierarchy.

Imagine a scenario with a degenerated association (field in the FactModel).

```ruby
[:sales_rep, { created_at: { datetime_drill: :month } }]
```

In this case, the dimension is Created_at and the Month is the desired hierarchy. But in the first example the :field option is the one defining the hierarchy. The degenerated example can also be written with the field option, but would be redundant.

```ruby
[:sales_rep, { created_at: { field: :created_at, datetime_drill: :month } }]
```

In order to avoid any conceptual misunderstanding about what is a dimension and what is a hierarchy, I believe datetime_drill is a better name. Another argument in favor of the drill name is that it only accepts datetime trunc functions, other hierarchies will not be accepted.

While I was codding I changed some others functions to make the code a little cleaner. I try my best to not break previous compatibility and I believe I was successful. The previous way and declaring dimensions like `[{ created_at: :month }]` still work.

What i did was add a deprecated warning when it is done, because on Degenerated Dimension the second parameter behave as datetime_drill operation but for Standard Dimension the second parameter will specify the column of table Ex: `[{ order: :created_at }]`. In this case drill operation will need a third parameter.

In the future we can stick with only the explicit use of drill operations and if a symbol is passed instead of a hash it will always be treated as a column selection. This will make the code simpler and some ifs can be removed.
Another thing that changed a little was the sql alias for the query, if you pass only a dimension symbol it will be used as alias for the select statement, that way old code using the gem will keep working. But if you change the column name of that dimension, the field will also be included in the alias, it will allow defining multiple dimensions over the same table without crashing.

Finally, you have a lot of code to review. good look ;)
