### PR TITLE
add date option to datetime drill

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ When creating a metric, ActiveReporting will recognize the following datetime hi
 - decade
 - century
 - millennium
+- date
 
 Under the hood Active Reporting uses specific database functions to manipulate datetime columns. Postgres provides a way to group by `datetime` column data on the fly using the [`date_trunc` function](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC). On Mysql this can be done using [Date and Time Functions](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html).
 

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -8,7 +8,7 @@ module ActiveReporting
     # Values for the Postgres `date_trunc` method.
     # See https://www.postgresql.org/docs/10/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
     DATETIME_HIERARCHIES = %i[microseconds milliseconds second minute hour day week month quarter year decade
-                              century millennium].freeze
+                              century millennium date].freeze
     JOIN_METHODS = { joins: :joins, left_outer_joins: :left_outer_joins }.freeze
     attr_reader :join_method, :label
 
@@ -188,7 +188,12 @@ module ActiveReporting
     end
 
     def datetime_drill_postgress(column)
-      "DATE_TRUNC('#{@datetime_drill}', #{column})"
+      case @datetime_drill.to_sym
+      when :date
+        "DATE('#{column})"
+      else
+        "DATE_TRUNC('#{@datetime_drill}', #{column})"
+      end
     end
 
     def datetime_drill_mysql(column)
@@ -219,6 +224,8 @@ module ActiveReporting
         "YEAR(#{column}) DIV 100"
       when :millennium
         "YEAR(#{column}) DIV 1000"
+      when :date
+        "DATE(#{column})"
       end
     end
 

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -190,7 +190,7 @@ module ActiveReporting
     def datetime_drill_postgress(column)
       case @datetime_drill.to_sym
       when :date
-        "DATE('#{column})"
+        "DATE('#{column}')"
       else
         "DATE_TRUNC('#{@datetime_drill}', #{column})"
       end

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -123,6 +123,18 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
     end
   end
 
+  def test_date_is_valid_datetime_drill
+    refute @user_dimension.hierarchical?
+    assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
+    if ['pg','mysql'].include?(ENV['DB'])
+      ActiveReporting::ReportingDimension.new(@user_dimension, datetime_drill: :date)
+    else
+      assert_raises ActiveReporting::InvalidDimensionLabel do
+        ActiveReporting::ReportingDimension.new(@user_dimension, datetime_drill: :date)
+      end
+    end
+  end
+
   def test_invalid_label_cannot_be_passed_in_if_dimension_is_datetime
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]


### PR DESCRIPTION
Needed a way to select the full date with year-month-day from a datetime column, therefore, I added a `date` option to DATETIME_HIERARCHIES array.

On mysql there is a `DATE()` function to do that:

```sql
mysql> select DATE("2010-02-05 3:00:00");
+----------------------------+
| DATE("2010-02-05 3:00:00") |
+----------------------------+
| 2010-02-05                 |
+----------------------------+
```

In order to also support this on postgres, I  used postgres `DATE()` function, because there is no such option on `date_trunc`

```sql
postgres=# SELECT DATE(TIMESTAMP '2020-02-05 3:00:00');
    date    
------------
 2020-02-05
```