### PR TITLE
WIP: Group results

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -40,8 +40,12 @@ module ActiveReporting
       @data = model.connection.exec_query(statement.to_sql).to_a
       apply_dimension_callbacks
       if @group_results
-        dimension_label_names = @dimensions.map { |d| d.label_name.to_s }
-        @data = Hash[@data.map { |r| [ r.fetch_values(*dimension_label_names), r.fetch(@metric.name.to_s)] }]
+        if @dimensions.any?
+          dimension_label_names = @dimensions.map { |d| d.label_name.to_s }
+          @data = Hash[@data.map { |r| [ r.fetch_values(*dimension_label_names), r.fetch(@metric.name.to_s)] }]
+        else
+          @data = Hash[@data.map { |r| [ r.keys, r.fetch(@metric.name.to_s)] }]
+        end
       end
       @data
     end

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -14,7 +14,7 @@ module ActiveReporting
     extend Forwardable
     def_delegators :@metric, :fact_model, :model
 
-    def initialize(metric, dimension_identifiers: true, dimension_filter: {}, dimensions: [], metric_filter: {}, raw_results: false)
+    def initialize(metric, dimension_identifiers: true, dimension_filter: {}, dimensions: [], metric_filter: {}, group_results: false)
       @metric = metric.is_a?(Metric) ? metric : ActiveReporting.fetch_metric(metric)
       raise UnknownMetric, "Unknown metric #{metric}" if @metric.nil?
 
@@ -24,7 +24,7 @@ module ActiveReporting
       @metric_filter          = @metric.metric_filter.merge(metric_filter)
       @ordering               = @metric.order_by_dimension
       partition_dimension_filters dimension_filter
-      @raw_results            = raw_results
+      @group_results          = group_results
     end
 
     # Builds and executes a query, returning the raw result
@@ -37,10 +37,11 @@ module ActiveReporting
     private ######################################################################
 
     def build_data
-      @data = model.connection.exec_query(statement.to_sql)
-      unless @raw_results
-        @data = @data.to_a
-        apply_dimension_callbacks
+      @data = model.connection.exec_query(statement.to_sql).to_a
+      apply_dimension_callbacks
+      if @group_results
+        dimension_label_names = @dimensions.map { |d| d.instance_variable_get(:@label_name).to_s }
+        @data = Hash[@data.map { |r| [ r.fetch_values(*dimension_label_names), r.fetch(@metric.name.to_s)] }]
       end
       @data
     end

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -40,7 +40,7 @@ module ActiveReporting
       @data = model.connection.exec_query(statement.to_sql).to_a
       apply_dimension_callbacks
       if @group_results
-        dimension_label_names = @dimensions.map { |d| d.instance_variable_get(:@label_name).to_s }
+        dimension_label_names = @dimensions.map { |d| d.label_name.to_s }
         @data = Hash[@data.map { |r| [ r.fetch_values(*dimension_label_names), r.fetch(@metric.name.to_s)] }]
       end
       @data

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -10,7 +10,7 @@ module ActiveReporting
     DATETIME_HIERARCHIES = %i[microseconds milliseconds second minute hour day week month quarter year decade
                               century millennium date].freeze
     JOIN_METHODS = { joins: :joins, left_outer_joins: :left_outer_joins }.freeze
-    attr_reader :join_method, :label
+    attr_reader :join_method, :label, :label_name
 
     def_delegators :@dimension, :name, :type, :klass, :association, :model, :hierarchical?
 


### PR DESCRIPTION
Continuing with Issue #41 I created a PR to demonstrate how we could group `metrics` by the `dimensions` to allow for easy charting by some popular gems e.g. chartkick.

The report object has a new option called `group_results` which can be passed `true` or `false`(default).  The default behaviour is unchanged and will return an Array of Hashes with metric name / value and dimension labels / values e.g. 
```
[ { metric_name => metric_value, dimension_1_label => dimension_1_value, dimension_2_label => dimension_2_value } ]
```
Setting `group_results` to true will return a hash with the keys containing the dimensions values and the values containing the metrics values e.g. 
```
{ [ dimension_1_value, dimension_2_value ] => metric_value }
```
If no dimensions have been defined in the report, it groups by the metric label e.g.
```
{ [ metric_name ] => metric_value }
```
This could be implemented as application logic in which case I think it would be helpful to expose the dimension names and metric names on the report object.  This could help turn this
```
metric = @report.instance_variable_get(:@metric).instance_variable_get(:@name)
dimensions = @report.instance_variable_get(:@dimensions).map { |d| d.instance_variable_get(:@label_name).to_s }
Hash[@report.run.map { |r| [ r.fetch_values(*dimensions), r.fetch(metric.to_s)] }]
```
into this
```
Hash[@report.run.map { |r| [ r.fetch_values(*@report.dimension_label_names), r.fetch(@report.metric_name)] }]
```

I have not written any tests yet.  I will look into this if the basic direction is okay.